### PR TITLE
[GraphQL] Nested Courses and Professors

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -89,7 +89,7 @@ const queryType = new GraphQLObjectType({
 
       // specify args to query by
       args: {
-        id: { type: GraphQLString }
+        id: { type: GraphQLString, description: "Course Department concatenated with Course Number. Ex: COMPSCI161" }
       },
 
       // define function to get a course
@@ -98,7 +98,7 @@ const queryType = new GraphQLObjectType({
       },
 
       // documentation
-      description: "Search courses by their course id. Ex: ICS46."
+      description: "Search courses by their course id. Ex: COMPSCI161"
     },
 
     // get professor by ucinetid
@@ -125,11 +125,7 @@ const queryType = new GraphQLObjectType({
 
       // get all courses from courses cache
       resolve: () => {
-        var coursesArr = []
-        for (var courseId in courses_cache){
-          coursesArr.push(courses_cache[courseId]);
-        }
-        return coursesArr;
+        return Object.values(courses_cache)
       },
 
       // documentation for all courses
@@ -142,11 +138,7 @@ const queryType = new GraphQLObjectType({
 
       // get all professors from cache
       resolve: () => {
-        var profArr = []
-        for (prof of professors_cache["hits"]["hits"]){
-          profArr.push(prof["_source"])
-        }
-        return profArr
+        return Object.values(professors_cache);
       },
 
       // documentation for all professors


### PR DESCRIPTION
## Summary
For nested fields that reference Course or Professor types, I replaced the course id/professor netid with the actual Course/Professor object.

Updated fields include:
- Course
    - professor_history -> [Professor]
    - prerequisite_list -> [Course]
    - dependencies -> [Course]

- Professor
    - course_history -> [Course]

TODO: when spaces within course id strings are purged from the cache, `the replace(/ /g, "")` code can be removed.

### Other Changes
Simplified allCourse/allProfessors resolvers, added descriptions.

## Test Plan
- Navigate to http://localhost:8080/graphql-playground
- Enter the following test queries and verify that the response is valid
```graphql
{ 
  professor(ucinetid: "pattis") {
    name
    course_history {
      id
      title
    }
  }
  course(id: "PHYSICS61B") {
    title
    prerequisite_list {
      id
      title
    }
    dependencies {
      id
      title
    }
    professor_history {
      name
      ucinetid
    }
  }
  allCourses {
    title
    id
  }
  allProfessors {
    title
    ucinetid
  }
}
```