### PR TITLE
Added Error JSONs for errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
 require('dotenv').config();
 
 var createError = require('http-errors');
+var {createErrorJSON} = require("./rest/v0/errors.helper")
 var express = require('express');
 var app = express();
 
@@ -47,7 +48,8 @@ app.use(function(err, req, res, next) {
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 
   // render the error page
-  res.status(err.status || 500).send(err.message);
+  var status = err.status || 500;
+  res.status(status).send(createErrorJSON(status, err.message, ""));
 });
 
 app.listen(port, function() {

--- a/rest/v0/router.js
+++ b/rest/v0/router.js
@@ -4,6 +4,7 @@ var router = express.Router();
 var coursesRouter = require("./courses");
 var gradesRouter = require("./grades");
 var instructorRouter = require("./instructor");
+var {createErrorJSON} = require("./errors.helper")
 
 router.get("/", (req,res) => {
     res.redirect('/docs')
@@ -12,5 +13,8 @@ router.get("/", (req,res) => {
 router.use("/courses", coursesRouter);
 router.use("/instructors", instructorRouter);
 router.use("/grades", gradesRouter);
+router.use("*", (req, res) => {
+    res.status(404).send(createErrorJSON(404, "Not Found", "The requested resource was not found."))
+});
 
 module.exports = router;


### PR DESCRIPTION
Turned errors into JSON responses for consistent REST formatting.

```
{
    "timestamp": "Wed, 27 Jan 2021 07:26:34 GMT",
    "status": 404,
    "error": "Not Found",
    "message": "The requested resource was not found."
}
```