### PR TITLE
Enabled proxy for heroku so it can use rate limiting library

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ var graphQLRouter = require('./graphql/router');
 var generateKey = require('./keys/generateKey');
 
 var app = express();
+app.set('trust proxy', 1);
 
 const limiter = rateLimit({
     windowMs: 60 * 1000, // 60 seconds * 1000ms


### PR DESCRIPTION
Rate limiting would not work behind a proxy like heroku, so added a line that enables it to work behind proxies. 