### PR TITLE
Add Grades query to GraphQL

### DIFF
--- a/rest/v0/grades.helper.js
+++ b/rest/v0/grades.helper.js
@@ -125,13 +125,17 @@ function queryDatabaseAndResponse(where, calculate, res) {
 
             res.send(result);
 
+            // Return for when this is called by GraphQL
+            return result;
+
             break;
         case false:
             let sqlQueryAll = "SELECT * FROM gradeDistribution";
-
-            res.send(connection.prepare(where !== null ? sqlQueryAll + where : sqlQueryAll).all());
-
-            break;
+            const queryResult = connection.prepare(where !== null ? sqlQueryAll + where : sqlQueryAll).all()
+            res.send(queryResult);
+            
+            // Return for when this is called by GraphQL
+            return queryResult;
     }
 
 }


### PR DESCRIPTION
The resolvers in this commit might just be the most poorly designed code I've ever written.
Essentially what we do is mock a call to Rest grades helper, then format that response to graphql.
It's horrible.

After HackUCI, we need to destroy all of the resolvers in this commit and restructure the project.
Helper functions should be shared between rest and graphql

## Test Plan
- navigate to /graphql-playground
- enter the following query
```graphql
{
  grades(instructor: "PATTIS, R."){
    aggregate {
      average_gpa
      sum_grade_a_count
      sum_grade_b_count
    }
    grade_distributions{
      average_gpa
      grade_a_count
      course_offering {
        course {
          title
        }
      }
    }
  }
}
```
- verify that it matches up with the results from `rest/v0/grades/calculated?instructor=PATTIS,%20R.` and `rest/v0/grades/raw?instructor=PATTIS,%20R.`
- Try several other queries use a range of the available parameters (year, instructor, department, quarter, number)