### PR TITLE
GraphQL: rename "professor" to "instructor"

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -10,8 +10,8 @@ var {getAllCourses, getCourse} = require('../helpers/courses.helper')
 var {getAllInstructors, getInstructor} = require('../helpers/instructor.helper')
 var {parseGradesParamsToSQL, queryDatabaseAndResponse} = require('../helpers/grades.helper')
 
-const professorType = new GraphQLObjectType({
-  name: 'Professor',
+const instructorType = new GraphQLObjectType({
+  name: 'Instructor',
   fields: () => ({
     name: { type: GraphQLString },
     ucinetid: { type: GraphQLString },
@@ -22,8 +22,8 @@ const professorType = new GraphQLObjectType({
     related_departments: { type: GraphQLList(GraphQLString) },
     course_history: { 
       type: GraphQLList(courseType),
-      resolve: (professor) => {
-        return getInstructor(professor.ucinetid)["course_history"].map(course_id => getCourse(course_id.replace(/ /g, "")));
+      resolve: (instructor) => {
+        return getInstructor(instructor.ucinetid)["course_history"].map(course_id => getCourse(course_id.replace(/ /g, "")));
       }
     }
   })
@@ -45,10 +45,10 @@ const courseType = new GraphQLObjectType({
     units: { type: GraphQLList(GraphQLFloat) },
     description: { type: GraphQLString },
     department_name: { type: GraphQLString },
-    professor_history: { 
-      type: GraphQLList(professorType),
+    instructor_history: { 
+      type: GraphQLList(instructorType),
       resolve: (course) => {
-        return getCourse(course.id.replace(/ /g, ""))["professor_history"].map(professor_netid => getInstructor(professor_netid));
+        return getCourse(course.id.replace(/ /g, ""))["professor_history"].map(instructor_netid => getInstructor(instructor_netid));
       } 
     },
     prerequisite_tree: { type: GraphQLString },
@@ -87,7 +87,7 @@ const courseOfferingType = new GraphQLObjectType({
     code: { type: GraphQLFloat },
     section: { type: GraphQLString },
     type: { type: GraphQLString },
-    instructor: { type: GraphQLString },  // TODO: map name to professorType
+    instructor: { type: GraphQLString },  // TODO: map name to instructorType
     course: { 
       type: courseType,
       resolve: (temp) => {
@@ -161,22 +161,22 @@ const queryType = new GraphQLObjectType({
       description: "Search courses by their course id. Ex: COMPSCI161"
     },
 
-    // get professor by ucinetid
-    professor: {
-      type: professorType,
+    // get instructor by ucinetid
+    instructor: {
+      type: instructorType,
 
       // specify args to query by (ucinetid)
       args: {
         ucinetid: { type: GraphQLString }
       },
 
-      // define function to get a professor
+      // define function to get a instructor
       resolve: (_, {ucinetid}) => {
         return getInstructor(ucinetid);
       },
 
-      // documentation for professor
-      description: "Search professors by their ucinetid"
+      // documentation for instructor
+      description: "Search instructors by their ucinetid"
     },
 
     // return all courses
@@ -192,17 +192,17 @@ const queryType = new GraphQLObjectType({
       description: "Return all courses. Takes no arguments"
     },
 
-    // return all professors
-    allProfessors: {
-      type: GraphQLList(professorType),
+    // return all instructor
+    allInstructors: {
+      type: GraphQLList(instructorType),
 
-      // get all professors from cache
+      // get all instructors from cache
       resolve: () => {
         return getAllInstructors();
       },
 
-      // documentation for all professors
-      description: "Return all professors. Takes no arguments"
+      // documentation for all instructors
+      description: "Return all instructors. Takes no arguments"
     },
 
     grades: {


### PR DESCRIPTION
To match REST, this renames all instances of "professor" to "instructor".
Affected areas include:
- allProfessors -> allInstructors
- professorType -> instructorType
- courseType.professorHistory -> courseType.instructorHistory

Test Plan
Verify the following queries still resolve properly
```graphql
{
    allInstructors {
        name
        title
    }
    instructor(ucinetid: "pattis") {
        name
        course_history {
            department_name
            title
            instructor_history {
                name
            }
        }
    }
}
```