### PR TITLE
Changed 'npm start' for server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon app",
+    "start": "nodemon server",
     "test": "jest",
     "init_db": "node ./db/sqlite.js",
     "refresh": "node ./utils/refreshESCache.js"


### PR DESCRIPTION
With the change for server.js, the `npm start` command has to be `nodemon server` instead of `app`. Now, it should consistently be started with `npm start`. 