### PR TITLE
Improve grades query speed, add instructors field

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -259,7 +259,11 @@ const gradeDistributionCollectionType = new GraphQLObjectType({
 
   fields: () => ({
     aggregate: { type: gradeDistributionCollectionAggregateType },
-    grade_distributions: {type: GraphQLList(gradeDistributionType)}
+    grade_distributions: {type: GraphQLList(gradeDistributionType)},
+    instructors: { 
+      type: GraphQLList(GraphQLString),
+      description: "List of instructors present in the Grade Distribution Collection" 
+    }
   })
 });
 
@@ -425,7 +429,8 @@ const queryType = new GraphQLObjectType({
         
         let result = {
           aggregate: aggregate,
-          grade_distributions: gradeDistributions
+          grade_distributions: gradeDistributions,
+          instructors: [...new Set(gradeResults.map(result => result.instructor))]
         }
         
         return result;

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -6,11 +6,14 @@ const {
   GraphQLList,
   GraphQLNonNull
 } = require('graphql');
+const {
+	parseResolveInfo,
+} = require('graphql-parse-resolve-info');
 
 var {getAllCourses, getCourse} = require('../helpers/courses.helper')
 var {getAllInstructors, getInstructor} = require('../helpers/instructor.helper')
 var {getCourseSchedules} = require("../helpers/schedule.helper")
-var {parseGradesParamsToSQL, queryDatabaseAndResponse} = require('../helpers/grades.helper');
+var {parseGradesParamsToSQL, fetchAggregatedGrades, fetchInstructors, fetchGrades} = require('../helpers/grades.helper');
 const { ValidationError } = require('../helpers/errors.helper');
 
 const instructorType = new GraphQLObjectType({
@@ -380,60 +383,83 @@ const queryType = new GraphQLObjectType({
         code: { type: GraphQLFloat }
       },
 
-      resolve: (_, args) => {
-        // Send request to rest
-        var query = {
-            ... args
+      resolve: (_, args, __, info) => {
+        // Get the fields requested in the query
+        // This allows us to only fetch what the client wants from sql
+        const requestedFields = Object.keys(parseResolveInfo(info).fieldsByTypeName.GradeDistributionCollection)
+      
+        // Construct a WHERE clause from the arguments
+        const where = parseGradesParamsToSQL(args);
+        
+        // If requested, retrieve the grade distributions
+        let grade_distributions, gradeResults;
+        if (requestedFields.includes('grade_distributions')) {
+          gradeResults = fetchGrades(where)
+
+          // Format the results to GraphQL
+          grade_distributions = gradeResults.map(result => {
+            return {
+              grade_a_count: result.gradeACount,
+              grade_b_count: result.gradeBCount,
+              grade_c_count: result.gradeCCount,
+              grade_d_count: result.gradeDCount,
+              grade_f_count: result.gradeFCount,
+              grade_p_count: result.gradePCount,
+              grade_np_count: result.gradeNPCount,
+              grade_w_count: result.gradeWCount,
+              average_gpa: result.averageGPA != "nan"? result.averageGPA : null,
+              course_offering: {
+                year: result.year,
+                quarter: result.quarter,
+                section: {
+                  code: result.code,
+                  number: result.section,
+                  type: result.type,
+                },
+                instructors: [result.instructor],
+                course: result.department.replace(/\s/g, '')+result.number,
+              }
+            }
+          })
         }
-        const where = parseGradesParamsToSQL(query);
-        const gradeResults = queryDatabaseAndResponse(where, false)
-        const aggregateResult = queryDatabaseAndResponse(where, true).gradeDistribution
-    
-        // Format to GraphQL
-        let aggregate = {
-          sum_grade_a_count: aggregateResult['SUM(gradeACount)'],
-          sum_grade_b_count: aggregateResult['SUM(gradeBCount)'],
-          sum_grade_c_count: aggregateResult['SUM(gradeCCount)'],
-          sum_grade_d_count: aggregateResult['SUM(gradeDCount)'],
-          sum_grade_f_count: aggregateResult['SUM(gradeFCount)'],
-          sum_grade_p_count: aggregateResult['SUM(gradePCount)'],
-          sum_grade_np_count: aggregateResult['SUM(gradeNPCount)'],
-          sum_grade_w_count: aggregateResult['SUM(gradeWCount)'],
-          average_gpa: aggregateResult['AVG(averageGPA)']
+        
+        // If requested, retrieve the aggregate
+        let aggregate;
+        if (requestedFields.includes('aggregate')) {
+          const aggregateResult = fetchAggregatedGrades(where)
+      
+          // Format results to GraphQL
+          aggregate = {
+            sum_grade_a_count: aggregateResult['SUM(gradeACount)'],
+            sum_grade_b_count: aggregateResult['SUM(gradeBCount)'],
+            sum_grade_c_count: aggregateResult['SUM(gradeCCount)'],
+            sum_grade_d_count: aggregateResult['SUM(gradeDCount)'],
+            sum_grade_f_count: aggregateResult['SUM(gradeFCount)'],
+            sum_grade_p_count: aggregateResult['SUM(gradePCount)'],
+            sum_grade_np_count: aggregateResult['SUM(gradeNPCount)'],
+            sum_grade_w_count: aggregateResult['SUM(gradeWCount)'],
+            average_gpa: aggregateResult['AVG(averageGPA)']
+          }
         }
 
-        let gradeDistributions = gradeResults.map(result => {
-          return {
-            grade_a_count: result.gradeACount,
-            grade_b_count: result.gradeBCount,
-            grade_c_count: result.gradeCCount,
-            grade_d_count: result.gradeDCount,
-            grade_f_count: result.gradeFCount,
-            grade_p_count: result.gradePCount,
-            grade_np_count: result.gradeNPCount,
-            grade_w_count: result.gradeWCount,
-            average_gpa: result.averageGPA != "nan"? result.averageGPA : null,
-            course_offering: {
-              year: result.year,
-              quarter: result.quarter,
-              section: {
-                code: result.code,
-                number: result.section,
-                type: result.type,
-              },
-              instructors: [result.instructor],
-              course: result.department.replace(/\s/g, '')+result.number,
-            }
+        // If requested, retrieve the instructors
+        let instructors
+        if (requestedFields.includes('instructors')) {
+          if (gradeResults) {
+            // If the grade results exist, we can get the instructors from there
+            instructors = [...new Set(gradeResults.map(result => result.instructor))]
+          } else {
+            // Else query sql for the instructors
+            instructors = fetchInstructors(where)
           }
-        })
-        
-        let result = {
-          aggregate: aggregate,
-          grade_distributions: gradeDistributions,
-          instructors: [...new Set(gradeResults.map(result => result.instructor))]
         }
         
-        return result;
+        // Return results
+        return {
+          aggregate,
+          grade_distributions,
+          instructors
+        }
       },
 
       description: "Search for grades."

--- a/helpers/grades.helper.js
+++ b/helpers/grades.helper.js
@@ -91,6 +91,37 @@ function parseGradesParamsToSQL(query) {
     return retVal;
 }
 
+function fetchGrades(where) {
+    let sqlStatement = "SELECT * FROM gradeDistribution";
+    return queryDatabase(where !== null ? sqlStatement + where : sqlStatement).all();
+}
+
+function fetchInstructors(where) {
+    let sqlStatement = "SELECT DISTINCT instructor FROM gradeDistribution";
+    return queryDatabase(where !== null ? sqlStatement + where : sqlStatement).all().map(result => result.instructor);
+}
+
+function fetchAggregatedGrades(where) {
+    let sqlStatement = `SELECT 
+                        SUM(gradeACount), 
+                        SUM(gradeBCount), 
+                        SUM(gradeCCount),
+                        SUM(gradeDCount),
+                        SUM(gradeFCount),
+                        SUM(gradePCount),
+                        SUM(gradeNPCount),
+                        SUM(gradeWCount),
+                        AVG(averageGPA),
+                        COUNT() FROM gradeDistribution`;
+
+    return queryDatabase(where !== null ? sqlStatement + where : sqlStatement).get();
+}
+
+function queryDatabase(statement) {
+    const connection = new db(path.join(__dirname, '../db/db.sqlite'));
+    return connection.prepare(statement)
+}
+
 function queryDatabaseAndResponse(where, calculate) {
     const connection = new db(path.join(__dirname, '../db/db.sqlite'));
 
@@ -140,4 +171,4 @@ function queryDatabaseAndResponse(where, calculate) {
 
 }
 
-module.exports = {parseGradesParamsToSQL, queryDatabaseAndResponse}
+module.exports = {parseGradesParamsToSQL, queryDatabaseAndResponse, fetchGrades, fetchAggregatedGrades, fetchInstructors}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,6 +5093,30 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
       "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
     },
+    "graphql-parse-resolve-info": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.11.0.tgz",
+      "integrity": "sha512-vIylHwlhtUz7y4UkXlwGRNIf1O2GhONRsZPYcz8SP+zI5Klp0aiulM4sQ7aEVJNbrqvzGj6cxthJLm+sys0dog==",
+      "requires": {
+        "debug": "^4.1.1",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "graphql-playground-html": {
       "version": "1.6.28",
       "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.28.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "flat-cache": "^2.0.1",
     "googleapis": "^67.0.0",
     "graphql": "^15.3.0",
+    "graphql-parse-resolve-info": "^4.11.0",
     "graphql-playground-middleware-express": "^1.7.21",
     "http-errors": "~1.6.3",
     "moesif-nodejs": "^3.1.5",

--- a/tests/int/graphql/grades.graphql.test.js
+++ b/tests/int/graphql/grades.graphql.test.js
@@ -53,6 +53,7 @@ describe('POST /graphql/', () => {
                   }
               }
             }
+            instructors
         }
     }`})
   .set('Accept', 'application/json')
@@ -89,8 +90,8 @@ describe('POST /graphql/', () => {
             "department": "I&C SCI",
             "number": "33",
         })
-    );
-    
+      );
+      expect(Array.isArray(response.body["data"]["grades"]["instructors"])).toBeTruthy();
   }));
 });
 


### PR DESCRIPTION
Previously when the grades query was called, it would send off SQL queries for everything (aggregate and grades distribution). Now it only queries for the requested field(s). If the client doesn't want the aggregate, we don't waste time fetching it.

This also adds the instructors field, which allows the client to see a list of all the instructors present in the response. 
Improvements compared to [getting all of the instructors from grade distributions](https://discord.com/channels/772739905981644850/780314631041318933/842567113678782484):
- 1.9MB -> 45.kB
- 1.4s -> 55ms  

(Closes #76)

# Test Plan
Verify that the new instructor field works
```
grades{
    instructors
}
```

Verify that everything else still works
```
grades(year: "2018-19" instructor: "PATTIS, R."){
    aggregate {
      sum_grade_a_count
    }
    grade_distributions {
      grade_a_count
      grade_p_count
      course_offering {
        instructors
        course {
          title
        }
      }
    }
    instructors
}
```