### PR TITLE
Fix average gpa empty string bug

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -443,7 +443,7 @@ const queryType = new GraphQLObjectType({
               grade_p_count: result.gradePCount,
               grade_np_count: result.gradeNPCount,
               grade_w_count: result.gradeWCount,
-              average_gpa: result.averageGPA != "nan"? result.averageGPA : null,
+              average_gpa: (result.averageGPA && result.averageGPA !== "nan") ? result.averageGPA : null,
               course_offering: {
                 year: result.year,
                 quarter: result.quarter,


### PR DESCRIPTION
Sometimes an empty string `''` or `'nan'` is returned in the grades results for averageGPA, causing a GraphQL error: `"Float cannot represent non numeric value: \"\""`.

This commit adds a simple check for the empty string scenario.

## Test Plan
Verify that the error is gone. Affected classes should have `null` for `average_gpa`.
```
{
    grades {
        grade_distributions {
            average_gpa
        }
    }
}
```