### PR TITLE
Improve safety of courseOfferingType's instructor resolve

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -173,10 +173,10 @@ const courseOfferingType = new GraphQLObjectType({
           if (ucinetids && ucinetids.length == 1) { return getInstructor(ucinetids[0]); }
           
           //If there is more than one, figure it out.
-          else if (ucinetids && ucinetids.length > 1) {
+          else if (ucinetids && ucinetids.length > 1 && (course = getCourse(temp.course))) {
               
               //Filter our instructors by those with related departments.
-              let course_dept = getCourse(temp.course).department;
+              let course_dept = course.department;
               let instructors = ucinetids.map(id => getInstructor(id)).filter( temp => temp.related_departments.includes(course_dept));
               
               //If only one is left, we can return it.


### PR DESCRIPTION
# Summary
The resolve func on instructor checks for a course's department to better determine who an instructor might be.

This adds a check to verify that the course id exists.
In some cases, a course id may not appear in our records because it is an old course.

# Test Plan
Verify no errors in graphql playground
```
{
  grades{
    grade_distributions {
      course_offering {
        instructors {
          name
          ucinetid
        }
      }
    }
  }
}
```

# Issues
Closes: #84 

# Followup
There's one instructor, `jyyu`, that exists in instructor_name_map.json but not parsed_professor_cache.json. This causes 7 errors of "Cannot read property 'related_departments' of null".   
It doesn't make sense to add a check for this scenario because if a ucinetid is returned from `getUCINetIDFromName`, that id should *always* exist in the professor cache. 
TODO: add `jyyu` to parsed_professor_cache.json