### PR TITLE
Adding gzip to all endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 2, //using second fastest compression level: https://www.npmjs.com/package/compression
+  level: 3 //using second fastest compression level: https://www.npmjs.com/package/compression
 }));
 app.use(logger('dev'));
 app.use(express.json());

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 3, //using third fastest compression level: https://www.npmjs.com/package/compression
+  level: 4, //using fourth fastest compression level: https://www.npmjs.com/package/compression
   threshold: "128kb",
   filter: (req, res) => {
     if (req.headers['x-no-compression']) {

--- a/app.js
+++ b/app.js
@@ -60,7 +60,9 @@ var corsOptions = {
   optionsSuccessStatus: 200
 }
 app.use(cors(corsOptions));
-app.use(compression());
+app.use(compression({
+  level: 1
+}));
 app.use(logger('dev'));
 app.use(express.json());
 app.use(limiter);

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var cors = require('cors');
 var path = require('path');
 var logger = require('morgan');
 const rateLimit = require("express-rate-limit");
+const compression = require("compression");
 const moesif = require('moesif-nodejs');
 const expressPlayground = require('graphql-playground-middleware-express').default;
 const Sentry = require("@sentry/node");
@@ -59,7 +60,7 @@ var corsOptions = {
   optionsSuccessStatus: 200
 }
 app.use(cors(corsOptions));
-
+app.use(compression());
 app.use(logger('dev'));
 app.use(express.json());
 app.use(limiter);

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 1, //using fastest compression level: https://www.npmjs.com/package/compression
+  level: 2, //using second fastest compression level: https://www.npmjs.com/package/compression
 }));
 app.use(logger('dev'));
 app.use(express.json());

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 3 //using second fastest compression level: https://www.npmjs.com/package/compression
+  level: 3 //using third fastest compression level: https://www.npmjs.com/package/compression
 }));
 app.use(logger('dev'));
 app.use(express.json());

--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 1
+  level: 1, //using fastest compression level: https://www.npmjs.com/package/compression
 }));
 app.use(logger('dev'));
 app.use(express.json());

--- a/app.js
+++ b/app.js
@@ -61,7 +61,17 @@ var corsOptions = {
 }
 app.use(cors(corsOptions));
 app.use(compression({
-  level: 3 //using third fastest compression level: https://www.npmjs.com/package/compression
+  level: 3, //using third fastest compression level: https://www.npmjs.com/package/compression
+  threshold: "128kb",
+  filter: (req, res) => {
+    if (req.headers['x-no-compression']) {
+        // don't compress responses if this request header is present
+        return false;
+    }
+
+    // fallback to standard compression
+    return compression.filter(req, res);
+}
 }));
 app.use(logger('dev'));
 app.use(express.json());

--- a/package-lock.json
+++ b/package-lock.json
@@ -3391,6 +3391,28 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@sentry/tracing": "^6.2.0",
     "better-sqlite3": "^7.1.1",
     "bottleneck": "^2.19.5",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "csv-parser": "^2.3.3",
     "debug": "~2.6.9",


### PR DESCRIPTION
I installed the package `compression` and have added it as middleware. 

Note: I used the third fastest level of compression based on the docs here: https://www.npmjs.com/package/compression. Upon testing, when using compression, download times are extremely low, but the TTFB (time to first byte, or until response from server), is higher. Compared to the default level compression will be faster, but downloads will take a little longer. Since TTFB is much longer, I went for faster compression to reduce that over download times.