### PR TITLE
User logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,16 @@ if (process.env.NODE_ENV == 'production') {
   
 }
 
+app.use(function(req, res, next) {
+  const event = {
+    Host: req.headers.host,
+    Referer: req.headers.referer,
+    Method: req.method,
+    url: req.url
+  }
+  console.log("EVENT\n" + JSON.stringify(event, null, 2))
+  next();
+});
 
 app.use(cors());
 app.use(compression({
@@ -102,6 +112,7 @@ app.use(function(err, req, res, next) {
 });
 
 module.exports = app;
+module.exports.handler = serverless(app, {binary: ['image/*']});
 
 if (process.env.NODE_ENV == "production") {
   const sentry_wrapper = Sentry.AWSLambda.wrapHandler(serverless(app, {binary: ['image/*']}));

--- a/app.js
+++ b/app.js
@@ -46,8 +46,8 @@ if (process.env.NODE_ENV == 'production') {
 }
 function logging(req, res, next) {
   const event = {
-    Referer: req.headers.referer,
-    Method: req.method,
+    referer: req.headers.referer,
+    method: req.method,
     url: req.originalUrl,
     body: req.body.query
   }

--- a/app.js
+++ b/app.js
@@ -47,7 +47,6 @@ if (process.env.NODE_ENV == 'production') {
 
 app.use(function(req, res, next) {
   const event = {
-    Host: req.headers.host,
     Referer: req.headers.referer,
     Method: req.method,
     url: req.url

--- a/app.js
+++ b/app.js
@@ -44,12 +44,12 @@ if (process.env.NODE_ENV == 'production') {
   });
   
 }
-
-app.use(function(req, res, next) {
+function logging(req, res, next) {
   const event = {
     Referer: req.headers.referer,
     Method: req.method,
-    url: req.originalUrl
+    url: req.originalUrl,
+    body: req.body.query
   }
   console.log("REQUEST\n" + JSON.stringify(event, null, 2));
   
@@ -63,9 +63,9 @@ app.use(function(req, res, next) {
     } else {
       console.log("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
     }
-  })
+  });
   next();
-});
+}
 
 app.use(cors());
 app.use(compression({
@@ -89,8 +89,8 @@ app.use(express.static("./docs-site"));
 app.use(express.static("./graphql/docs"));
 app.set('view engine', 'ejs')
 
-app.use("/rest", restRouter);
-app.use("/graphql", graphQLRouter);
+app.use("/rest", logging, restRouter);
+app.use("/graphql", logging, graphQLRouter);
 app.use('/graphql-playground', expressPlayground({endpoint: '/graphql/'}));
 app.use('/docs', express.static('docs-site'));
 app.use('/error', function(req, res, next) {

--- a/app.js
+++ b/app.js
@@ -49,9 +49,21 @@ app.use(function(req, res, next) {
   const event = {
     Referer: req.headers.referer,
     Method: req.method,
-    url: req.url
+    url: req.originalUrl
   }
-  console.log("EVENT\n" + JSON.stringify(event, null, 2))
+  console.log("REQUEST\n" + JSON.stringify(event, null, 2));
+  
+  res.on('finish', () => {
+    const finishEvent = {
+      statusCode: res.statusCode,
+      statusMessage: res.statusMessage
+    }
+    if (finishEvent.statusCode >= 400) {
+      console.error("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
+    } else {
+      console.log("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
+    }
+  })
   next();
 });
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ provider:
   region: us-east-1
   stage: prod
   memorySize: 512
+  logRetentionInDays: 90
   apiGateway:
     binaryMediaTypes:
       - 'image/*'


### PR DESCRIPTION
## Reference Issues
Closes #107 

## Summary of Change/Fix 
Adds new logging functionality for each request for REST and GraphQL endpoints to track referers. This is a sample request/response logging. In JSON format, to allow CloudWatch to parse and create queries for our logs.

```
REQUEST
{
  "referer": "http://localhost:8080/graphql-playground",
  "method": "POST",
  "url": "/graphql/",
  "body": "{\n  instructor(ucinetid: \"ardalan\") {\n    name\n    shortened_name\n    email\n    ucinetid\n  }\n}\n"
}

RESPONSE
{
  "statusCode": 200,
  "statusMessage": "OK"
}

```

## Test Plan
Make requests to graphql and rest, and verify logs are printed out. 