### PR TITLE
Added Course Level Division Filter to Grades Queries

### DIFF
--- a/db/sqlite.js
+++ b/db/sqlite.js
@@ -10,6 +10,7 @@ const gradeDistributionTableSchema = `
         department char(12) NOT NULL,
         department_name varchar(64) NOT NULL,
         number char(6) NOT NULL,
+        number_int int NOT NULL,
         code int NOT NULL,
         section char(6) NOT NULL,
         title varchar(64) NOT NULL,
@@ -39,6 +40,7 @@ const gradeDistributionInsertQuery = `
         department, 
         department_name,
         number, 
+        number_int,
         code, 
         section, 
         title, 
@@ -53,7 +55,7 @@ const gradeDistributionInsertQuery = `
         gradeNPCount,
         gradeWCount,
         averageGPA) 
-        VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
     );
 `;
 
@@ -94,6 +96,7 @@ function insertData() {
                 row.dept_code, 
                 row.dept,
                 row.number, 
+                row.number.replace(/\D/g,''),
                 row.code, 
                 row.section, 
                 row.title, 

--- a/docs/REST-API/grades.md
+++ b/docs/REST-API/grades.md
@@ -107,7 +107,7 @@ Try out one of these quick ways to play with our grades endpoints:
 | `number` | Course number | 32A |
 | `code` | 5-digit course code on WebSoC | 35540 |
 | `division` | Filter by Course Level (Lower and Upper Division) | LowerDiv/UpperDiv |
-| `excludePNP` | Exclude P/NP | true/false |
+| `excludePNP` | Exclude P/NP Only courses | true/false |
 
 
 !!! tip 

--- a/docs/REST-API/grades.md
+++ b/docs/REST-API/grades.md
@@ -105,7 +105,8 @@ Try out one of these quick ways to play with our grades endpoints:
 | `instructor` | Instructor, must following the format (<last_name\>, <first_initial\>.) |  PATTIS, R. |
 | `department` | Department short-hand | I&C SCI |
 | `number` | Course number | 32A |
-|  `code` | 5-digit course code on WebSoC | 35540 |
+| `code` | 5-digit course code on WebSoC | 35540 |
+| `division` | Filter by Course Level (Lower and Upper Division) | LowerDiv/UpperDiv |
 | `excludePNP` | Exclude P/NP | true/false |
 
 

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -443,13 +443,14 @@ const queryType = new GraphQLObjectType({
       type: gradeDistributionCollectionType,
 
       args: {
-        year: { type: GraphQLString },
-        quarter: { type: GraphQLString },
-        instructor: { type: GraphQLString },
-        department: { type: GraphQLString },
-        number: { type: GraphQLString },
-        code: { type: GraphQLString }, 
-        excludePNP: { type: GraphQLBoolean }
+        year: { type: GraphQLString, description: "Must be <START_YEAR>-<END_YEAR>. Ex. 2020-2021"},
+        quarter: { type: GraphQLString, description: "Fall | Winter | Spring | Summer"},
+        instructor: { type: GraphQLString, description: "Instructor, must following the format (<last_name>, <first_initial>.)"},
+        department: { type: GraphQLString, description: "Department short-hand"},
+        number: { type: GraphQLString, description: "Course number"},
+        code: { type: GraphQLString, description: "5-digit course code on WebSoC" }, 
+        division: { type: GraphQLString, description: "Filter by Course Level ('LowerDiv'|'UpperDiv')"},
+        excludePNP: { type: GraphQLBoolean, description: "Exclude P/NP Only courses" }
       },
 
       resolve: (_, args, __, info) => {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -443,12 +443,12 @@ const queryType = new GraphQLObjectType({
       type: gradeDistributionCollectionType,
 
       args: {
-        year: { type: GraphQLString, description: "Must be <START_YEAR>-<END_YEAR>. Ex. 2020-2021"},
-        quarter: { type: GraphQLString, description: "Fall | Winter | Spring | Summer"},
-        instructor: { type: GraphQLString, description: "Instructor, must following the format (<last_name>, <first_initial>.)"},
-        department: { type: GraphQLString, description: "Department short-hand"},
-        number: { type: GraphQLString, description: "Course number"},
-        code: { type: GraphQLString, description: "5-digit course code on WebSoC" }, 
+        year: { type: GraphQLString, description: "Must be <START_YEAR>-<END_YEAR>. Ex. 2020-2021. Multiple values in the arguments can be included by using ; as a separator."},
+        quarter: { type: GraphQLString, description: "Fall | Winter | Spring | Summer Multiple values in the arguments can be included by using ; as a separator."},
+        instructor: { type: GraphQLString, description: "Instructor, must following the format (<last_name>, <first_initial>.) Multiple values in the arguments can be included by using ; as a separator."},
+        department: { type: GraphQLString, description: "Department short-hand. Ex. COMPSCI. Multiple values in the arguments can be included by using ; as a separator."},
+        number: { type: GraphQLString, description: "Course number. Multiple values in the arguments can be included by using ; as a separator."},
+        code: { type: GraphQLString, description: "5-digit course code on WebSoC. Multiple values in the arguments can be included by using ; as a separator." }, 
         division: { type: GraphQLString, description: "Filter by Course Level ('LowerDiv'|'UpperDiv')"},
         excludePNP: { type: GraphQLBoolean, description: "Exclude P/NP Only courses" }
       },
@@ -538,7 +538,7 @@ const queryType = new GraphQLObjectType({
         }
       },
 
-      description: "Search for grades."
+      description: "Search for grade distributions. Multiple values in the arguments can be included by using ; as a separator. "
     }
 })});
 

--- a/helpers/grades.helper.js
+++ b/helpers/grades.helper.js
@@ -14,7 +14,8 @@ function parseGradesParamsToSQL(query) {
         'instructor': query.instructor ? query.instructor.split(";") : null,
         'department': query.department ? query.department.split(";") : null,
         'number': query.number ? query.number.split(";") : null,
-        'code': query.code ? query.code.split(";") : null
+        'code': query.code ? query.code.split(";") : null,
+        'division': query.division ? query.division: null
     }
 
     Object.keys(params).forEach(function(key) {
@@ -81,6 +82,20 @@ function parseGradesParamsToSQL(query) {
                     }
                 }
                 break;
+            case key == 'division' && params[key] !== null:
+                let division = params[key].toLowerCase();
+                if (division == "lowerdiv") {
+                    condition == "" ? 
+                        condition += "number_int < 100" : 
+                        condition += " OR number_int < 100" 
+                } else if (division == "upperdiv") {
+                    condition == "" ? 
+                        condition += "number_int BETWEEN 100 AND 199" : 
+                        condition += " OR number_int BETWEEN 100 AND 199" 
+                } else {
+                    throw new ValidationError(errorMsg(params[key], "division"))
+                }
+
         }
         
         whereClause === "" ?  

--- a/tests/int/grades.int.test.js
+++ b/tests/int/grades.int.test.js
@@ -67,6 +67,61 @@ describe('GET /grades/raw', () => {
 });
 
 describe('GET /grades/raw', () => {
+    it('returns a json of filtered grades distribution',  () => request
+    .get('/rest/v0/grades/raw?year=2018-19;2019-20&instructor=PATTIS, R.&department=I%26C SCI&quarter=Fall&number=33&division=LowerDiv')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        expect(Array.isArray(response.body)).toBeTruthy();
+        expect(response.body.length).toBeGreaterThan(0);
+        expect(response.body[0]).toEqual(expect.objectContaining({
+            "year": expect.any(String),
+            "instructor": "PATTIS, R.",
+            "code": expect.any(Number)
+        }));
+    }));
+});
+
+describe('GET /grades/raw', () => {
+    it('returns a json of filtered grades distribution',  () => request
+    .get('/rest/v0/grades/raw?year=2018-19;2019-20&instructor=PATTIS, R.&department=I%26C SCI&quarter=Fall&division=UpperDiv')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        expect(Array.isArray(response.body)).toBeTruthy();
+        expect(response.body.length).toBeGreaterThan(0);
+        expect(response.body[0]).toEqual(expect.objectContaining({
+            "year": expect.any(String),
+            "instructor": "PATTIS, R.",
+            "code": expect.any(Number)
+        }));
+        expect(parseInt(response.body[0].number.replace(/\D/g,''))).toBeGreaterThan(99);
+    }));
+});
+
+describe('GET /grades/raw', () => {
+    it('returns a json of filtered grades distribution',  () => request
+    .get('/rest/v0/grades/raw?year=2018-19;2019-20&instructor=PATTIS, R.&department=I%26C SCI&quarter=Fall&division=LowerDiv')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        expect(Array.isArray(response.body)).toBeTruthy();
+        expect(response.body.length).toBeGreaterThan(0);
+        response.body.map((resp) => {
+            expect(resp).toEqual(expect.objectContaining({
+                "year": expect.any(String),
+                "instructor": "PATTIS, R.",
+                "code": expect.any(Number)
+            }));
+            expect(parseInt(resp.number.replace(/\D/g,''))).toBeLessThan(99);
+        })
+    }));
+});
+
+describe('GET /grades/raw', () => {
     it('invalid parameters to /grades/raw', () => request
     .get('/rest/v0/grades/raw?year=2017-18&instructor=PATTIS, R.&code=33')
     .set('Accept', 'application/json')

--- a/tests/unit/grades.helper.unit.test.js
+++ b/tests/unit/grades.helper.unit.test.js
@@ -1,6 +1,6 @@
 var {parseGradesParamsToSQL, queryDatabaseAndResponse} = require('../../helpers/grades.helper')
 
-const expectedSQL = " WHERE (year = '2019-20') AND (quarter = 'SPRING') AND (instructor = 'CARVALHO, J.') AND (department = 'ECON') AND (number = '100B') AND (code = '62110')";
+const expectedSQL = " WHERE (year = '2019-20') AND (quarter = 'SPRING') AND (instructor = 'CARVALHO, J.') AND (department = 'ECON') AND (number = '100B') AND (code = '62110') AND (number_int BETWEEN 100 AND 199)";
 
 describe('Test parseGradesParamsToSQL', () => {
     it('returns SQL from grades parameters', () => {
@@ -10,7 +10,8 @@ describe('Test parseGradesParamsToSQL', () => {
             code: '62110',
             department: 'ECON',
             number: '100B',
-            quarter: 'SPRING'
+            quarter: 'SPRING',
+            division: 'UpperDiv'
         };
         const sqlParams = parseGradesParamsToSQL(rawParams);
         expect(sqlParams).not.toBeNull();


### PR DESCRIPTION
## Reference Issues
Closes #131 and #123

## Summary of Change/Fix 
Created a course level division parameter, so you can filter grades data by lower and upper division classes.

Adds a field for `number_int` for the integer of the course number to the grades db. This number is then used to check if a course in our db is lower division (less than 100), or upper division (between 100 and 199). 

Added descriptions to the graphql playgound for grades, so they can see these in the playground, and what types of inputs they need. Also changed in grades.md, to now be `Exclude P/NP Only courses`.

Added unit tests to check that this feature is working.

## Test Plan
Run `npm test`

Test out these queries in GraphQL:

Check that the course numbers for this are all less than 100. 
```
{
  grades (year:"2020-21", department:"I&C SCI", division:"LowerDiv") {
		grade_distributions {
      course_offering {
        year
        quarter
        course {
            department
            number
            title
        }
      }
    }
  }
}
```

Check that the course numbers for this are all greater than or equal to 100 and less than 200.
```
{
  grades (year:"2020-21", department:"I&C SCI", division:"UpperDiv") {
		grade_distributions {
      course_offering {
        year
        quarter
        course {
            department
            number
            title
        }
      }
    }
  }
}
```

Verify this endpoint also has only lower div classes:
http://localhost:8000/rest/v0/grades/raw?term=2020%20Fall&department=I%26C%20SCI&division=lowerdiv

Verify this has only upper div:
http://localhost:8000/rest/v0/grades/raw?term=2020%20Fall&department=I%26C%20SCI&division=upperdiv