### PR TITLE
Fix fonts in REST API docs

### DIFF
--- a/docs/REST-API/grades.md
+++ b/docs/REST-API/grades.md
@@ -80,7 +80,7 @@ Try out one of these quick ways to play with our grades endpoints:
     </div>
 
 
-### /grades/raw
+### `/grades/raw`
 **GET a list of grade distribution results via a query/**
 
 #### Parameters
@@ -187,7 +187,7 @@ Try out one of these quick ways to play with our grades endpoints:
     
     ```
 
-### /grades/calculated
+### `/grades/calculated`
 **GET a list of grade distribution results via a query/**
 
 #### Parameters

--- a/docs/REST-API/instructors.md
+++ b/docs/REST-API/instructors.md
@@ -83,7 +83,7 @@ None. 💃
     ]
     ```
 
-### /instructors/{ucinetid}
+### `/instructors/{ucinetid}`
 
 **GET detailed information on a specific instructor**
 

--- a/docs/REST-API/schedule.md
+++ b/docs/REST-API/schedule.md
@@ -147,7 +147,7 @@ Try out one of these quick ways to play with our grades endpoints:
     </div>
 
 
-### /schedule/soc
+### `/schedule/soc`
 
 **GET schedule of classes data**
 


### PR DESCRIPTION
## Reference Issues
#130

## Summary of Change/Fix 
Formatted headers in the REST API documentation as code blocks.

## Test Plan
Serve the docs pages as a site using `mkdocs serve`.
Visit the following pages:
```
http://127.0.0.1:8000//REST-API/instructors/
http://127.0.0.1:8000//REST-API/grades/
http://127.0.0.1:8000//REST-API/schedule/
```
and ensure that the headers for each endpoint are formatted as code blocks.

## Before
![before](https://user-images.githubusercontent.com/29588832/151122438-d7618e94-74fd-4b75-a349-d160cb7ca4cb.png)

## After
![after](https://user-images.githubusercontent.com/29588832/151122481-d5b5dd31-fd08-4b3b-8a86-3efa6c1d22ce.png)

