### PR TITLE
Fixed Bug with Wrong Instructor for Common Names

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -202,8 +202,7 @@ const courseOfferingType = new GraphQLObjectType({
               
               //If only one is left and it's in the instructor cache, we can return it.
               if (instructors.length == 1) {
-                const instructor = getInstructor(ucinetids[0]);
-                if (instructor) { return instructor; }  
+                return instructors[0];
               } else {
                 //Filter instructors by those that taught the course before.
                 instructors = instructors.filter( inst => {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -211,8 +211,7 @@ const courseOfferingType = new GraphQLObjectType({
               
                 //If only one is left and it's in the instructor cache, we can return it.
                 if (instructors.length == 1) { 
-                  const instructor = getInstructor(ucinetids[0]);
-                  if (instructor) { return instructor; }  
+                  return instructors[0];
                 }
               }
           }


### PR DESCRIPTION
## Reference Issues
Just discovered and fixed this bug on my own, no relevant issues. 

## Summary of Change/Fix 
Was messing with API, and found that 

This query would return the wrong instructor for some of these courses. We added something to match instructors based on departments. I found a bug that it would return the result from the wrong array, and thus returning the wrong instructor. 

```
{
  schedule(year:2022, quarter:"Spring", instructor:"SMITH, J.") {
    id
    number
    department
    offerings {
      instructors {
        name
      }
    }
  }
}
```
Previously, this query returned only `Jaymi Lee Smith`, for all results. Now, it is actually correct.

## Test Plan
I used instructors "SMITH, J.", and "HU, Y." as examples. In the original API, it would return the same one for all of them. Test them locally in the graphql playground here, and it should return the correct ones.

```
{
  schedule(year:2022, quarter:"Spring", instructor:"SMITH, J.") {
    id
    number
    department
    offerings {
      instructors {
        name
      }
    }
  }
}
```
```
{
  schedule(year:2022, quarter:"Spring", instructor:"HU, Y.") {
    id
    number
    department
    offerings {
      instructors {
        name
      }
    }
  }
}
```