### PR TITLE
Update schedule query to return courseOffering

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -135,8 +135,8 @@ const courseType = new GraphQLObjectType({
             course_number: course.number, 
             ...args
           })
-          const results = (await getCourseSchedules(query))[0];
-          return results.offerings;
+          const results = await getCourseSchedules(query);
+          return results;
         }
 
         // TODO: only return one error for a query, instead of one per item in the list
@@ -403,7 +403,7 @@ const queryType = new GraphQLObjectType({
     },
 
     schedule: {
-      type: GraphQLList(courseType),
+      type: GraphQLList(courseOfferingType),
 
       args: {
         year: { type: GraphQLNonNull(GraphQLFloat), description: "Year of the term. Required." },

--- a/helpers/schedule.helper.js
+++ b/helpers/schedule.helper.js
@@ -31,19 +31,20 @@ async function getCourseSchedules(query) {
     const results = await callWebSocAPI(query);
     const year = query.term.split(" ")[0]
     const quarter = query.term.split(" ")[1]
-    var courses = [];
+    var offerings = [];
     for (const school of results["schools"]) {
         for (const dept of school["departments"]) {
             for (const course of dept["courses"]) {
                 const courseID = (course["deptCode"] + course["courseNumber"]).replace(/ /g, "", "");
-                courses.push({
-                    offerings: course["sections"].map(section => _formatCourseOffering(section, {course: courseID, year, quarter})),
-                    ...getCourse(courseID),
+                course["sections"].forEach(section => {
+                    offerings.push(
+                        _formatCourseOffering(section, {course: getCourse(courseID), year, quarter})
+                    )
                 })
             }
         }
     }
-    return courses
+    return offerings
 }
   
 module.exports = {getCourseSchedules}

--- a/tests/int/graphql/schedule.graphql.test.js
+++ b/tests/int/graphql/schedule.graphql.test.js
@@ -9,35 +9,31 @@ describe('POST /graphql/', () => {
     .post('/graphql/')
     .send({query:`{
         schedule(year: 2019, quarter: "Fall", department:"COMPSCI", course_number: "161") {
-          title
-          id
-          offerings {
-            year
-            quarter
-            instructors {
-              ucinetid
-              name
-              department
-            }
-            final_exam
-            max_capacity
-            meetings {
-              time
-              building
-              days
-            }
-            num_section_enrolled
-            num_total_enrolled
-            num_on_waitlist
-            num_requested
-            num_new_only_reserved
-            units
-            restrictions
-            status
-            course {
-              title
-              id
-            }
+          year
+          quarter
+          instructors {
+            ucinetid
+            name
+            department
+          }
+          final_exam
+          max_capacity
+          meetings {
+            time
+            building
+            days
+          }
+          num_section_enrolled
+          num_total_enrolled
+          num_on_waitlist
+          num_requested
+          num_new_only_reserved
+          units
+          restrictions
+          status
+          course {
+            title
+            id
           }
         }
       }`})
@@ -48,10 +44,9 @@ describe('POST /graphql/', () => {
         expect(response.body).toHaveProperty('data');
         expect(response.body["data"]).toHaveProperty('schedule');
         expect(Array.isArray(response.body["data"]["schedule"])).toBeTruthy();
-        expect(response.body["data"]["schedule"][0]["title"]).toEqual("Design and Analysis of Algorithms");
-        expect(response.body["data"]["schedule"][0]["id"]).toEqual("COMPSCI161");
-        expect(Array.isArray(response.body["data"]["schedule"][0]["offerings"])).toBeTruthy();
-        expect(response.body["data"]["schedule"][0]["offerings"][0]).toEqual(
+        expect(response.body["data"]["schedule"][0]["course"]["title"]).toEqual("Design and Analysis of Algorithms");
+        expect(response.body["data"]["schedule"][0]["course"]["id"]).toEqual("COMPSCI161");
+        expect(response.body["data"]["schedule"][0]).toEqual(
           expect.objectContaining({
             "year": "2019",
             "quarter": "Fall",
@@ -78,13 +73,11 @@ describe('POST /graphql/', () => {
     .post('/graphql/')
     .send({query:`{
         schedule(year: 2019, quarter: "Fall", department:"COMPSCI", course_number: "100") {
-            offerings {
-                year
-                max_capacity
-                num_total_enrolled
-            }
+          year
+          max_capacity
+          num_total_enrolled
         }
-        }`})
+      }`})
     .set('Accept', 'application/json')
     .expect('Content-Type', /json/)
     .expect(200)


### PR DESCRIPTION
## Reference Issues
Closes #159

## Summary of Change/Fix 
The `schedule` query used to return a courseType. This doesn't really make sense though since the client cares more about the `courseOffering` information. 

Now the `schedule` query **returns a `courseOffering` object** directly. The user can still get the `course` data from `courseOffering` if they want it.

## Test Plan
- `npm run test`

- Test the `schedule` query and test the nested `offerings` field in the `course` query`
```graphql
query {
  schedule(year: 2021 quarter: "Fall" ge: "GE-2") {
    section {
      code
      type
    }
    final_exam
    meetings {
      days
      time
    }
    course {
      id
      title
    }
  }
  course(id: "COMPSCI161") {
    title
    offerings(quarter: "Fall" year: 2021) {
      section {
      	code
      	type
    	}
    	final_exam
      meetings {
        days
        time
      }
        course {
          title
        }
      }
  }
}
```
