### PR TITLE
Added option for flag to show logs

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ if (process.env.NODE_ENV == 'production') {
   
 }
 function logging(req, res, next) {
-  if (process.argv.includes("--logging") || process.env.NODE_ENV == "production") {
+  if (process.argv.includes("--log") || process.env.NODE_ENV == "production") {
     const event = {
       referer: req.headers.referer,
       method: req.method,

--- a/app.js
+++ b/app.js
@@ -45,25 +45,27 @@ if (process.env.NODE_ENV == 'production') {
   
 }
 function logging(req, res, next) {
-  const event = {
-    referer: req.headers.referer,
-    method: req.method,
-    url: req.originalUrl,
-    body: req.body.query
+  if (process.argv.includes("--logging") || process.env.NODE_ENV == "production") {
+    const event = {
+      referer: req.headers.referer,
+      method: req.method,
+      url: req.originalUrl,
+      body: req.body.query
+    }
+    console.log("REQUEST\n" + JSON.stringify(event, null, 2));
+    
+    res.on('finish', () => {
+      const finishEvent = {
+        statusCode: res.statusCode,
+        statusMessage: res.statusMessage
+      }
+      if (finishEvent.statusCode >= 400) {
+        console.error("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
+      } else {
+        console.log("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
+      }
+    });
   }
-  console.log("REQUEST\n" + JSON.stringify(event, null, 2));
-  
-  res.on('finish', () => {
-    const finishEvent = {
-      statusCode: res.statusCode,
-      statusMessage: res.statusMessage
-    }
-    if (finishEvent.statusCode >= 400) {
-      console.error("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
-    } else {
-      console.log("RESPONSE\n" + JSON.stringify(finishEvent, null, 2));
-    }
-  });
   next();
 }
 


### PR DESCRIPTION
## Reference Issues
Closes #160 

## Summary of Change/Fix 
Hides logging for local development if not desired. Now, the user has an option to set a flag to show logging. They can specify by setting a flag when running the start script. If we are in `production`, then logging will always occur, so we can see them in CloudWatch.

Without logs:
`npm start`

With logs:
`npm start -- --log`
This is how npm lets us use arguments. Even though it looks weird, I don't see another way. 

I'm also open to changing the name of the flag. I'm not sure what word might be best. I've considered: 
- `logs`
- `logging`

## Test Plan
Run `npm start` to check that logs do not appear. 
Run `npm start -- --log` to check that logs do appear.