### PR TITLE
Fixed instructor resolve returning null in offering

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -206,7 +206,7 @@ const courseOfferingType = new GraphQLObjectType({
               } else {
                 //Filter instructors by those that taught the course before.
                 instructors = instructors.filter( inst => {
-                  return history = inst.course_history.map((course) => course.replace(/ /g, "")).includes(offering.course.id);
+                  return inst.course_history.map((course) => course.replace(/ /g, "")).includes(offering.course.id);
                 });
               
                 //If only one is left and it's in the instructor cache, we can return it.

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -194,7 +194,7 @@ const courseOfferingType = new GraphQLObjectType({
           
           //If there is more than one and the course exists, 
           //use the course to figure it out.
-          else if (ucinetids && ucinetids.length > 1 && (course = getCourse(offering.course))) {
+          else if (ucinetids && ucinetids.length > 1 && (course = offering.course)) {
 
               //Filter our instructors by those with related departments.
               let course_dept = course.department;
@@ -206,7 +206,7 @@ const courseOfferingType = new GraphQLObjectType({
               } else {
                 //Filter instructors by those that taught the course before.
                 instructors = instructors.filter( inst => {
-                  return inst.course_history.map((course) => getCourse(course.replace(/ /g, ""))).includes(offering.course);
+                  return history = inst.course_history.map((course) => course.replace(/ /g, "")).includes(offering.course.id);
                 });
               
                 //If only one is left and it's in the instructor cache, we can return it.


### PR DESCRIPTION
## Summary of Change/Fix 
Bug discovered in recent PR #161 . 
In this query, with a common name, the instructor resolver had errors, because the structure of offerings was changed. This will fix that bug so the instructor resolver now finds the instructor properly.
```
{
    schedule(year: 2022, quarter: "Spring", instructor: "SMITH, J.") {
      year
      instructors {
        name
        shortened_name
      }
    }
  }
```
Future Changes: Add a test for the instructor resolver.
## Test Plan
Run query and check that the instructors `name` field is not null for "SMITH, J.". 
```
{
  schedule(year: 2022, quarter: "Spring", instructor: "SMITH, J.") {
    year
    course {
      id
    }
    instructors {
        name
        shortened_name
      }
  }
  
  course(id:"DRAMA240") {
    offerings(year:2022, quarter:"Spring") {
      instructors {
        name
        shortened_name
      }
    }
  }
}
```