### PR TITLE
Fixed grammar issue: courses information -> course information

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ![petr](https://github.com/icssc-projects/peterportal-public-api/blob/master/public/images/peterportal-banner-logo.png?raw=true)
 
-PeterPortal Public API provides software developers with easy-access to UC Irvine publicly available data such as: courses information, professor information, grade distribution, and schedule of classes.
+PeterPortal Public API provides software developers with easy-access to UC Irvine publicly available data such as: course information, professor information, grade distribution, and schedule of classes.
 
 🔨 Built with:
 


### PR DESCRIPTION
## Reference Issues
Closes #174 

## Summary of Change/Fix 
Fixed a grammar issue: "courses information -> course information"

## Test Plan
Verified change using "npm start" on local host